### PR TITLE
Add support for cookie options

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,16 +11,14 @@ Authors@R:
       person(given = "Klaus",
              family = "Hartl",
              role = c("ctb", "cph"),
-             comment = "Author of JS-Cookies"),
-      person(given = "Klaus",
-             family = "Hartl",
-             role = c("ctb", "cph"),
-             comment = "Author of JS-Cookies"))
+             comment = "Author of JS-Cookies")
+    )
 Description: Set and get browser cookies in 'Shiny' through 
     'JS-cookie'.
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1
 Imports: 
     shiny
+Roxygen: list(markdown = TRUE)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 export(Cookie)
 export(add_cookie)
+export(cookie_options)
 export(fetch_cookie)
 export(fetch_cookies)
 export(remove_cookie)

--- a/R/cookies.R
+++ b/R/cookies.R
@@ -41,67 +41,99 @@ use_glouton <- function(online = TRUE){
 #' `fetch_cookies` returns all the cookies, while `fetch_cookie` search for
 #' one cookie in the browser.
 #'
-#' @param session the `input` and `session` object from Shiny
-#' @param name name of the cookie to set/fetch
-#' @param value the value to set for the cookie
+#' @param session The `session` object passed to function given to
+#'   `shinyServer`. Default is [shiny::getDefaultReactiveDomain()]
+#' @param name Name of the cookie to set/fetch
+#' @param value The value to set for the cookie
+#' @param options A list of options returned from `cookie_options()`. The same
+#'   options that were passed to `add_cookie()` must be passed to
+#'   `remove_cookie()`.
+#' @param debug If `TRUE`, a message is displayed in the browser console after
+#'   adding a cookie.
+#' @param expires Define when the cookie will be removed. Value must be a
+#'   numeric, which will be interpreted as days from time of creation or
+#'   a date. If `NULL`, the cookie becomes a session cookie.
+#' @param path A string indicating the path where the cookie is visible.
+#' @param domain A string indicating a valid domain where the cookie should be
+#'   visible. The cookie will also be visible to all subdomains.
+#' @param secure Boolean indicating whether the cookie transmission requires a
+#'   secure protocol (https).
+#' @param sameSite A string allowing to control whether the browser is sending
+#'   a cookie along with cross-site requests.
 #'
 #' @export
 #' @rdname cookies
 
-fetch_cookies <- function(session = NULL){
-  if(is.null(session))
-    session <- shiny::getDefaultReactiveDomain()
+fetch_cookies <- function(session = shiny::getDefaultReactiveDomain()){
   session$sendCustomMessage("fetchcookies", TRUE)
   return(session$input[["gloutoncookies"]])
 }
 
 #' @export
 #' @rdname cookies
-fetch_cookie <- function(name, session = NULL){
-  if(is.null(session))
-    session <- shiny::getDefaultReactiveDomain()
+fetch_cookie <- function(name, session = shiny::getDefaultReactiveDomain()){
   session$sendCustomMessage("fetchcookie", TRUE)
   return(session$input[["gloutoncookies"]])
 }
 
 #' @export
 #' @rdname cookies
-add_cookie <- function(name, value, session = NULL){
-  if(is.null(session))
-    session <- shiny::getDefaultReactiveDomain()
+add_cookie <- function(name,
+                       value,
+                       options = cookie_options(),
+                       debug = FALSE,
+                       session = shiny::getDefaultReactiveDomain())
+{
   session$sendCustomMessage("addcookie", list(
-    name = name, value = value
+    name = name, value = value, options = options, debug = debug
   ))
 }
 
 #' @export
 #' @rdname cookies
-remove_cookie <- function(name, session = NULL){
-  if(is.null(session))
-    session <- shiny::getDefaultReactiveDomain()
+remove_cookie <- function(name,
+                          options = cookie_options(),
+                          session = shiny::getDefaultReactiveDomain()){
   session$sendCustomMessage("rmcookie", list(
-    name = name
+    name = name, options = options
   ))
 }
 
+#' @export
+#' @rdname cookies
+cookie_options <- function(expires = NULL,
+                           path = "/",
+                           domain = NULL,
+                           secure = FALSE,
+                           sameSite = "strict"
+) {
+  options <- list(
+    expires = expires,
+    path = path,
+    domain = domain,
+    secure = secure,
+    sameSite = sameSite
+  )
+
+  # Drop NULLs
+  options[lengths(options) != 0]
+}
+
 #' Create a Cookie
-#' 
+#'
 #' Create a cookie object.
-#' 
+#'
 #' @export
 Cookie <- R6::R6Class(
   "Cookie",
   public = list(
 #' @details Create a Cookie
-#' 
+#'
 #' @param name The name of the cookie.
 #' @param session A valid Shiny session.
-    initialize = function(name, session = NULL){
+    initialize = function(name, session = shiny::getDefaultReactiveDomain()){
       if(missing(name))
         stop("Missing `name`", call. = FALSE)
-
-      if(is.null(session))
-        session <- shiny::getDefaultReactiveDomain()
 
       private$.session <- session
       private$.name <- name
@@ -113,7 +145,7 @@ Cookie <- R6::R6Class(
       invisible(rez)
     },
 #' @details Set the value of the cookie
-#' 
+#'
 #' @param value Value of the cookie
 #' @param expires When the cookie is set to expire, integer indicating number of days.
 #' @param path Path where cookie is visible.
@@ -127,7 +159,7 @@ Cookie <- R6::R6Class(
       )
 
       private$.session$sendCustomMessage("set-cookie", list(name = private$.name, value = value, options = options))
-      
+
       invisible(self)
     },
 #' @details Remove the cookie.

--- a/glouton.Rproj
+++ b/glouton.Rproj
@@ -18,3 +18,4 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/inst/example_app.R
+++ b/inst/example_app.R
@@ -4,10 +4,14 @@ ui <- function(request){
     use_glouton(),
     textInput("cookie_name", "cookie name"),
     textInput("cookie_content", "cookie content"),
+    numericInput("expires_in", "Expires in", min = 0, value = 365),
+    selectInput("sameSite", "sameSite", c("strict", "lax", "none")),
     actionButton("setcookie", "Add cookie"),
-    actionButton("getcookie", "get cookie"),
-    verbatimTextOutput("cook"),
-    verbatimTextOutput("one")
+    p(
+      "Use the developer tools to see the log which is created when debug=TRUE."
+    ),
+    p("Cookies.get():"),
+    verbatimTextOutput("cook")
   )
 }
 
@@ -15,15 +19,27 @@ server <- function(input, output, session){
 
   r <- reactiveValues()
 
-  observeEvent( input$setcookie , {
-    add_cookie(input$cookie_name, input$cookie_content, session)
+  options_r <- shiny::reactive({
+    cookie_options(
+      expires = input$expires_in,
+      path = "/",
+      secure = TRUE,
+      sameSite = input$sameSite
+    )
   })
-  observeEvent( input$getcookie , {
-    r$cook <- fetch_cookies(session, input)
+
+  observeEvent( input$setcookie , {
+    add_cookie(
+      name = input$cookie_name,
+      value = input$cookie_content,
+      options = options_r(),
+      debug = TRUE
+    )
   })
 
   output$cook <- renderPrint({
-    r$cook
+    input$gloutoncookies
+    fetch_cookies(session)
   })
 
 }

--- a/inst/glouton.js
+++ b/inst/glouton.js
@@ -16,7 +16,8 @@ $(document).on('shiny:connected', function(event) {
   });
 
   Shiny.addCustomMessageHandler('addcookie', function(arg) {
-    Cookies.set(arg.name, arg.value);
+    var c = Cookies.set(arg.name, arg.value, arg.options);
+    if (arg.debug) console.log(c);
     sendCookies();
   });
 

--- a/man/Cookie.Rd
+++ b/man/Cookie.Rd
@@ -18,9 +18,10 @@ Create a cookie object.
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
 \subsection{Method \code{new()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Cookie$new(name, session = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Cookie$new(name, session = shiny::getDefaultReactiveDomain())}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -39,6 +40,7 @@ Create a Cookie
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-get"></a>}}
+\if{latex}{\out{\hypertarget{method-get}{}}}
 \subsection{Method \code{get()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Cookie$get()}\if{html}{\out{</div>}}
@@ -51,6 +53,7 @@ Get the value of the cookie
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-set"></a>}}
+\if{latex}{\out{\hypertarget{method-set}{}}}
 \subsection{Method \code{set()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Cookie$set(value, expires = 365L, path = "/")}\if{html}{\out{</div>}}
@@ -74,6 +77,7 @@ Set the value of the cookie
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-rm"></a>}}
+\if{latex}{\out{\hypertarget{method-rm}{}}}
 \subsection{Method \code{rm()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Cookie$rm()}\if{html}{\out{</div>}}
@@ -86,6 +90,7 @@ Remove the cookie.
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/cookies.Rd
+++ b/man/cookies.Rd
@@ -5,24 +5,66 @@
 \alias{fetch_cookie}
 \alias{add_cookie}
 \alias{remove_cookie}
+\alias{cookie_options}
 \title{Add and fetch browsers cookies}
 \usage{
-fetch_cookies(session = NULL)
+fetch_cookies(session = shiny::getDefaultReactiveDomain())
 
-fetch_cookie(name, session = NULL)
+fetch_cookie(name, session = shiny::getDefaultReactiveDomain())
 
-add_cookie(name, value, session = NULL)
+add_cookie(
+  name,
+  value,
+  options = cookie_options(),
+  debug = FALSE,
+  session = shiny::getDefaultReactiveDomain()
+)
 
-remove_cookie(name, session = NULL)
+remove_cookie(
+  name,
+  options = cookie_options(),
+  session = shiny::getDefaultReactiveDomain()
+)
+
+cookie_options(
+  expires = NULL,
+  path = "/",
+  domain = NULL,
+  secure = FALSE,
+  sameSite = "strict"
+)
 }
 \arguments{
-\item{session}{the `input` and `session` object from Shiny}
+\item{session}{The \code{session} object passed to function given to
+\code{shinyServer}. Default is \code{\link[shiny:domains]{shiny::getDefaultReactiveDomain()}}}
 
-\item{name}{name of the cookie to set/fetch}
+\item{name}{Name of the cookie to set/fetch}
 
-\item{value}{the value to set for the cookie}
+\item{value}{The value to set for the cookie}
+
+\item{options}{A list of options returned from \code{cookie_options()}. The same
+options that were passed to \code{add_cookie()} must be passed to
+\code{remove_cookie()}.}
+
+\item{debug}{If \code{TRUE}, a message is displayed in the browser console after
+adding a cookie.}
+
+\item{expires}{Define when the cookie will be removed. Value must be a
+numeric, which will be interpreted as days from time of creation or
+a date. If \code{NULL}, the cookie becomes a session cookie.}
+
+\item{path}{A string indicating the path where the cookie is visible.}
+
+\item{domain}{A string indicating a valid domain where the cookie should be
+visible. The cookie will also be visible to all subdomains.}
+
+\item{secure}{Boolean indicating whether the cookie transmission requires a
+secure protocol (https).}
+
+\item{sameSite}{A string allowing to control whether the browser is sending
+a cookie along with cross-site requests.}
 }
 \description{
-`fetch_cookies` returns all the cookies, while `fetch_cookie` search for
+\code{fetch_cookies} returns all the cookies, while \code{fetch_cookie} search for
 one cookie in the browser.
 }


### PR DESCRIPTION
Hello Colin,

I added support for cookie options in the initial set of functions and did further small changes.

- Added `cookie_options()`
- Added argument `debug` to `add_cookie()`
- Removed duplicate author from DESCRIPTION
- Shortened handling of `session` argument
- Extended example app

Best regards
David